### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if (DEFINED PROJECT_NAME)
 endif ()
 
 set (BITFLAGS_VERSION_MAJOR 1)
-set (BITFLAGS_VERSION_MINOR 0)
+set (BITFLAGS_VERSION_MINOR 2)
 set (BITFLAGS_VERSION_PATCH 0)
 
 set (BITFLAGS_VERSION "${BITFLAGS_VERSION_MAJOR}.${BITFLAGS_VERSION_MINOR}.${BITFLAGS_VERSION_PATCH}")
@@ -89,6 +89,9 @@ if (BITFLAGS_BUILD_TESTS)
 endif ()
 
 if (NOT BITFLAGS_SUBPROJECT)
+    include(CMakePackageConfigHelpers)
+    include(GNUInstallDirs)
+    
     configure_package_config_file (
         bitflags_config.cmake.in
             ${CMAKE_CURRENT_BINARY_DIR}/bitflags_config.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ if (NOT BITFLAGS_SUBPROJECT)
 
     write_basic_package_version_file (
         bitflags-config-version.cmake
-        VERSION ${PACKAGE_VERSION}
+        VERSION ${BITFLAGS_VERSION}
         COMPATIBILITY AnyNewerVersion
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.12")
         bitflags
             VERSION ${BITFLAGS_VERSION}
             LANGUAGES CXX
-            HOMEPAGE_URL "https://github.com/m-peko/smart-enum"
+            HOMEPAGE_URL "https://github.com/m-peko/bitflags"
             DESCRIPTION ""
     )
 elseif (CMAKE_VERSION VERSION_GREATER_EQUAL "3.9")
@@ -92,29 +92,23 @@ if (NOT BITFLAGS_SUBPROJECT)
     include(CMakePackageConfigHelpers)
     include(GNUInstallDirs)
     
-    configure_package_config_file (
-        bitflags_config.cmake.in
-            ${CMAKE_CURRENT_BINARY_DIR}/bitflags_config.cmake
-            INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/bitflags
-    )
+    install (TARGETS bitflags EXPORT bitflags-config)
 
     write_basic_package_version_file (
-        bitflags_config_version.cmake
-            COMPATIBILITY AnyNewerVersion
+        bitflags-config-version.cmake
+        VERSION ${PACKAGE_VERSION}
+        COMPATIBILITY AnyNewerVersion
     )
 
-    install (TARGETS bitflags EXPORT bitflags_targets)
-
     install (
-        EXPORT bitflags_targets
-        FILE bitflags_targets.cmake
+        EXPORT bitflags-config
+        FILE bitflags-config.cmake
         NAMESPACE bitflags::
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/bitflags
     )
 
     install (
-        FILES ${CMAKE_CURRENT_BINARY_DIR}/bitflags_config.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/bitflags_config_version.cmake
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/bitflags-config-version.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/bitflags
     )
 

--- a/bitflags_config.cmake.in
+++ b/bitflags_config.cmake.in
@@ -1,7 +1,0 @@
-@PACKAGE_INIT@
-
-include(CMakeFindDependencyMacro)
-
-if (NOT TARGET smart_enum::smart_enum)
-  include (${CMAKE_CURRENT_LIST_DIR}/smart_enum_targets.cmake)
-endif ()


### PR DESCRIPTION
* Added missing modules
* Used correct minor version
* Renamed `_config` to `-config` as `find_package` only looks for `XXConfig` or `XX-config` not `XX_config`
* Removed `bitflags_targets` and `bitflags_config.cmake.in`. You don't have any dependencies so that's not really doing anything (it also used the old library name).